### PR TITLE
Simplified Collection API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A JavaScript client for [Cliquet](https://github.com/mozilla-services/cliquet/).
 
-This is work in progress, there's no code just yet.
+This is work in progress, and documented API isn't fully implemented just yet. Don't use it for serious things.
 
 ## Installation
 
@@ -24,7 +24,7 @@ This is work in progress, there's no code just yet.
 ### The `Cliquetis` constructor
 
 ```js
-var db = new Cliquetis(options);
+const db = new Cliquetis(options);
 ```
 
 `options` is an object defining the following option values:
@@ -38,9 +38,7 @@ var db = new Cliquetis(options);
 Selecting a collection is done by calling the `collection()` method, passing it the resource name:
 
 ```js
-db.collection("articles").then(function(articles) {
-  // you can now use the articles collection object
-});
+const articles = db.collection("articles");
 ```
 
 The collection object has the following attributes:
@@ -54,9 +52,8 @@ All operations are asynchronous and rely on [Promises](https://developer.mozilla
 ### Creating a record
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.save({title: "foo"});
-}).then(console.log.bind(console));
+articles.save({title: "foo"})
+  .then(console.log.bind(console));
 ```
 
 Result is:
@@ -76,9 +73,7 @@ Result is:
 ### Retrieving a single record
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.get("2dcd0e65-468c-4655-8015-30c8b3a1c8f8");
-})
+articles.get("2dcd0e65-468c-4655-8015-30c8b3a1c8f8")
   .then(console.log.bind(console))
   .catch(console.error.bind(console));
 ```
@@ -110,9 +105,8 @@ var updated = Object.assign(existing, {
   title: "baz"
 });
 
-db.collection("articles").then(function(articles) {
-  articles.save(updated);
-}).then(console.log.bind(console));
+articles.save(updated)
+  .then(console.log.bind(console));
 ```
 
 Result is:
@@ -132,9 +126,8 @@ Result is:
 #### Single unique record passing its `id`:
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.delete("2dcd0e65-468c-4655-8015-30c8b3a1c8f8");
-}).then(console.log.bind(console));
+articles.delete("2dcd0e65-468c-4655-8015-30c8b3a1c8f8")
+  .then(console.log.bind(console));
 ```
 
 Result:
@@ -153,21 +146,18 @@ Result:
 #### Multiple deletions using a query
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.delete({
-    filter: {
-      age: { $gte: 42 }
-    }
-  });
+articles.delete({
+  filter: {
+    age: { $gte: 42 }
+  }
 }).then(console.log.bind(console));
 ```
 
 ### Listing records
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.list();
-})..then(console.log.bind(console));
+articles.list()
+  .then(console.log.bind(console));
 ```
 
 Result is:
@@ -193,31 +183,25 @@ Result is:
 #### Filtering
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.list({
-    filter: { unread: { $eq: true } }
-  });
+articles.list({
+  filter: { unread: { $eq: true } }
 }).then(console.log.bind(console));
 ```
 
 #### Sorting
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.list({
-    sort: ["-unread", "-added_on"]
-  });
+articles.list({
+  sort: ["-unread", "-added_on"]
 }).then(console.log.bind(console));
 ```
 
 #### Combining `sort` and `filter`
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.list({
-    filter: { unread: { $eq: true } },
-    sort: ["-added_on"]
-  });
+articles.list({
+  filter: { unread: { $eq: true } },
+  sort: ["-added_on"]
 }).then(console.log.bind(console));
 ```
 
@@ -226,9 +210,8 @@ db.collection("articles").then(function(articles) {
 This will remove all existing records from the collection:
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.clear();
-}).then(console.log.bind(console));
+articles.clear()
+  .then(console.log.bind(console));
 ```
 
 Result:
@@ -245,17 +228,15 @@ Result:
 Synchronizing local data with remote ones is performed by calling the `.sync()` method:
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.sync();
-}).then(console.log.bind(console));
+articles.sync()
+  .then(console.log.bind(console));
 ```
 
 Note that you can override default options by passing it a new options object, Cliquetis will merge these new values with the default ones:
 
 ```js
-db.collection("articles").then(function(articles) {
-  return articles.sync({mode: Cliquet.FORCE});
-}).then(console.log.bind(console));
+articles.sync({mode: Cliquet.FORCE})
+  .then(console.log.bind(console));
 ```
 
 Result:

--- a/src/collection.js
+++ b/src/collection.js
@@ -15,7 +15,7 @@ export default class Collection {
     return this._name;
   }
 
-  init() {
+  open() {
     if (this._db)
       return Promise.resolve(this);
     return new Promise((resolve, reject) => {
@@ -53,7 +53,7 @@ export default class Collection {
   }
 
   clear() {
-    return this.init().then(() => {
+    return this.open().then(() => {
       return new Promise((resolve, reject) => {
         const {transaction, store} = this.prepare("readwrite");
         store.clear();
@@ -71,7 +71,7 @@ export default class Collection {
   }
 
   _create(record) {
-    return this.init().then(() => {
+    return this.open().then(() => {
       return new Promise((resolve, reject) => {
         var {transaction, store} = this.prepare("readwrite");
         var newRecord = Object.assign({}, record, {id: uuid4()});
@@ -90,7 +90,7 @@ export default class Collection {
   }
 
   _update(record) {
-    return this.init().then(() => {
+    return this.open().then(() => {
       return this.get(record.id).then(_ => {
         return new Promise((resolve, reject) => {
           var {transaction, store} = this.prepare("readwrite");
@@ -112,13 +112,13 @@ export default class Collection {
   save(record) {
     if (typeof(record) !== "object")
       return Promise.reject(new Error('Record is not an object.'));
-    return this.init().then(() => {
+    return this.open().then(() => {
       return record.id ? this._update(record) : this._create(record);
     });
   }
 
   get(id) {
-    return this.init().then(() => {
+    return this.open().then(() => {
       return new Promise((resolve, reject) => {
         var {transaction, store} = this.prepare();
         var request = store.get(id);
@@ -138,7 +138,7 @@ export default class Collection {
   }
 
   delete(id) {
-    return this.init().then(() => {
+    return this.open().then(() => {
       // Ensure the record actually exists.
       return this.get(id).then(result => {
         return new Promise((resolve, reject) => {
@@ -159,7 +159,7 @@ export default class Collection {
   }
 
   list() {
-    return this.init().then(() => {
+    return this.open().then(() => {
       return new Promise((resolve, reject) => {
         var results = [];
         const {transaction, store} = this.prepare();

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,7 @@ export default class Cliquetis {
 
   collection(collName) {
     if (!collName)
-      return Promise.reject(new Error("missing collection name"));
-    return new Promise((resolve, reject) => {
-      // if collection collName is missing, reject
-      resolve(new Collection(collName).init());
-    });
+      throw new Error("missing collection name");
+    return new Collection(collName);
   }
 }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -15,22 +15,22 @@ describe("Cliquetis", function() {
   }
 
   beforeEach(function() {
-    return testCollection().then(articles => articles.clear());
+    return testCollection().clear();
   });
 
   describe("#collection()", function() {
-    it("should return a Promise", function() {
-      return testCollection().should.be.fulfilled;
+    it("should return a Collection", function() {
+      expect(testCollection()).to.be.a("object");
     });
 
     it("should resolve to a named collection instance", function() {
-      return testCollection()
-        .should.eventually.have.property("name").eql(TEST_COLLECTION_NAME);
+      expect(testCollection().name).eql(TEST_COLLECTION_NAME);
     });
 
     it("should reject on missing collection name", function() {
-      return new Cliquetis().collection()
-        .should.be.rejected;
+      expect(function() {
+        new Cliquetis().collection();
+      }).to.Throw(Error, /missing collection name/);
     });
   });
 
@@ -39,66 +39,54 @@ describe("Cliquetis", function() {
 
     describe("#save", function() {
       it("should save a record and return saved record data", function() {
-        return testCollection().then(function(articles) {
-          return articles.save(article);
-        }).should.eventually.have.property("data");
+        return testCollection().save(article)
+          .should.eventually.have.property("data");
       });
 
       it("should save a record and return saved record perms", function() {
-        return testCollection().then(function(articles) {
-          return articles.save(article);
-        }).should.eventually.have.property("permissions");
+        return testCollection().save(article)
+          .should.eventually.have.property("permissions");
       });
 
       it("should assign an id to the saved record", function() {
-        return testCollection().then(function(articles) {
-          return articles.save(article)
-            .then(result => result.data.id);
-        }).should.eventually.be.a("string");
+        return testCollection().save(article)
+          .then(result => result.data.id)
+          .should.eventually.be.a("string");
       });
 
       it("should not alter original record", function() {
-        return testCollection().then(function(articles) {
-          return articles.save(article);
-        }).should.eventually.not.eql(article);
+        return testCollection().save(article)
+          .should.eventually.not.eql(article);
       });
 
       it("should reject if passed argument is not an object", function() {
-        return testCollection().then(function(articles) {
-          return articles.save(42);
-        }).should.eventually.be.rejectedWith(Error, /is not an object/);
+        return testCollection().save(42)
+          .should.eventually.be.rejectedWith(Error, /is not an object/);
       });
 
       it("should actually persist the record into the collection", function() {
-        var articles;
-        return testCollection().then(function(collection) {
-          articles = collection;
-          return articles.save(article);
-        }).then(result => {
+        var articles = testCollection();
+        return articles.save(article).then(result => {
           return articles.get(result.data.id).then(res => res.data.title);
         }).should.become(article.title);
       });
 
       it("should update a record", function() {
-        var articles;
-        return testCollection().then(function(collection) {
-          articles = collection;
-          return articles.save(article).then(res => res.data.id);
-        }).then(id => {
-          return articles.get(id).then(res => res.data);
-        }).then(existingArticle => {
-          return articles.save(Object.assign({}, existingArticle, {
-            title: "new title"
-          })).then(res => res.data.id);
-        }).then(id => {
-          return articles.get(id).then(res => res.data.title);
-        }).should.become("new title");
+        var articles = testCollection();
+        return articles.save(article)
+          .then(res => articles.get(res.data.id))
+          .then(res => res.data)
+          .then(existing => {
+            return articles.save(Object.assign({}, existing, {title: "new title"}))
+          })
+          .then(res => articles.get(res.data.id))
+          .then(res => res.data.title)
+          .should.become("new title");
       });
 
       it("should reject updates on a non-existent record", function() {
-        return testCollection().then(function(articles) {
-          return articles.save({id: "non-existent"});
-        }).should.be.rejectedWith(Error, /not found/);
+        return testCollection().save({id: "non-existent"})
+          .should.be.rejectedWith(Error, /not found/);
       });
     });
 
@@ -106,24 +94,20 @@ describe("Cliquetis", function() {
       var uuid;
 
       beforeEach(function() {
-        return testCollection().then(articles => {
-          return articles.save(article)
-            .then(result => uuid = result.data.id);
-        });
+        return testCollection().save(article)
+          .then(result => uuid = result.data.id);
       });
 
       it("should retrieve a record from its id", function() {
-        return testCollection().then(articles => {
-          return articles.get(uuid).then(res => res.data);
-        }).should.eventually.eql(Object.assign({}, article, {
-          id: uuid
-        }));
+        return testCollection().get(uuid)
+          .then(res => res.data)
+          .should.eventually.eql(Object.assign({}, article, {id: uuid}));
       });
 
       it("should reject in case of record not found", function() {
-        return testCollection().then(articles => {
-          return articles.get("non-existent").then(res => res.data);
-        }).should.be.rejectedWith(Error, /not found/);
+        return testCollection().get("non-existent")
+          .then(res => res.data)
+          .should.be.rejectedWith(Error, /not found/);
       });
     });
 
@@ -131,39 +115,36 @@ describe("Cliquetis", function() {
       var uuid;
 
       beforeEach(function() {
-        return testCollection().then(articles => {
-          return articles.save(article)
-            .then(result => uuid = result.data.id);
-        });
+        return testCollection().save(article)
+          .then(result => uuid = result.data.id);
       });
 
       it("should delete a record", function() {
-        return testCollection().then(articles => {
-          return articles.delete(uuid).then(res => res.data);
-        }).should.eventually.eql({id: uuid, deleted: true});
+        return testCollection().delete(uuid)
+          .then(res => res.data)
+          .should.eventually.eql({id: uuid, deleted: true});
       });
 
       it("should reject on non-existent record", function() {
-        return testCollection().then(articles => {
-          return articles.delete("non-existent").then(res => res.data);
-        }).should.eventually.be.rejectedWith(Error, /not found/);
+        return testCollection().delete("non-existent")
+          .then(res => res.data)
+          .should.eventually.be.rejectedWith(Error, /not found/);
       });
     });
 
     describe("#list", function() {
       beforeEach(function() {
-        return testCollection().then(articles => {
-          return Promise.all([
-            articles.save(article),
-            articles.save({title: "bar", url: "http://bar"})
-          ]);
-        });
+        var articles = testCollection();
+        return Promise.all([
+          articles.save(article),
+          articles.save({title: "bar", url: "http://bar"})
+        ]);
       });
 
       it("should retrieve the list of records", function() {
-        return testCollection().then(articles => {
-          return articles.list().then(res => res.data);
-        }).should.eventually.have.length.of(2);
+        return testCollection().list()
+          .then(res => res.data)
+          .should.eventually.have.length.of(2);
       });
     });
   });


### PR DESCRIPTION
Our current `Cliquetis#collection` returns a Promise, which makes users writing a bunch of boilerplate for no obvious reason:

```js
var db = new Cliquetis();
db.collection("articles").then(function(articles) {
  return articles.save({title: "foo"});
}).then(…);
```

This patch updates this method so it directly returns a `Collection` instance, which will ensure for every of its method calls that the db is opened, resulting in a much more lighweight usage:

```js
var db = new Cliquetis();
db.collection("articles").save({title: "foo"}).then(…);
```

r=? @leplatrem 